### PR TITLE
Parse frame bookend

### DIFF
--- a/assets/js/liveParser.ts
+++ b/assets/js/liveParser.ts
@@ -6,6 +6,7 @@ import type {
   PlayerState,
   CommandPayloadSizes,
   GameEvent,
+  FrameBookend,
 } from "~/common/types";
 import { WorkerState } from "./worker";
 
@@ -86,6 +87,10 @@ function parseEvent(
     case 0x3b:
       const itemUpdate = parseItemUpdateEvent(rawData, offset, replayVersion);
       gameEvent = { type: "item_update", data: itemUpdate };
+      break;
+    case 0x3c:
+      const frameBookendEvent = parseFrameBookendEvent(rawData, offset, replayVersion);
+      gameEvent = { type: "frame_bookend", data: frameBookendEvent };
       break;
   }
 
@@ -813,6 +818,19 @@ function parseGameEndEvent(
           : "No Contest",
       quitInitiator,
     };
+  }
+}
+
+function parseFrameBookendEvent(
+  rawData: DataView,
+  offset: number,
+  replayVersion: string
+): FrameBookend {
+  return {
+    frameNumber:
+      readInt(rawData, 32, replayVersion, "3.0.0.0", offset + 0x01) + 123,
+    latestFinalizedFrame:
+      readInt(rawData, 32, replayVersion, "3.7.0.0", offset + 0x05) + 123,
   }
 }
 

--- a/assets/js/liveParser.ts
+++ b/assets/js/liveParser.ts
@@ -42,27 +42,12 @@ export function parsePacket(rawPacket: Uint8Array, workerState: WorkerState): Ga
   return gameEvents;
 }
 
-// Ok we actually maybe don't want to return a frame here because a frame
-// is created and updated across different slippi events
-// ACTUALLY: Frame events are batched together over the network
-// - this function should be recursive or something and return a Frame at the end
-
-// flow:
-// 1. receive frame start event; get or initialize frame
-// 2. receive a series of frame update events; mutate frame
-// 3. at the end, return the frame, and update it in state within the store
-//
-// What happens when this differs though?
-// Maybe could have a parseEvent-type function, which gets called from a
-// higher level (something similar to but not equal parseFrame, or just the store).
-// parseEvent: (rawPacket, offset, replayVersion, frames, payloadSizes) -> [newOffset, frame]
-
 function parseEvent(
   rawData: DataView,
   offset: number,
   workerState: WorkerState
 ): [number, GameEvent | null] {
-  const replayVersion = '3.18.0.0'; // TODO: replayVersion
+  const replayVersion = workerState.replayFormatVersion ?? '3.18.0.0';
   const payloadSizes = workerState.payloadSizes;
 
   const command = readUint(rawData, 8, replayVersion, firstVersion, offset);
@@ -75,6 +60,7 @@ function parseEvent(
       return [offset + commandPayloadSizes[command] + 0x01, gameEvent];
     case 0x36:
       const gameSettings = parseGameStartEvent(rawData, offset, /* metadata */);
+      workerState.replayFormatVersion = gameSettings.replayFormatVersion;
       gameEvent = { type: "game_start", data: gameSettings };
       break;
     case 0x37:

--- a/assets/js/worker.ts
+++ b/assets/js/worker.ts
@@ -15,9 +15,19 @@ import { parsePacket } from "./liveParser";
 
 type WorkerInput = { type: "connect", value: string };
 
-export type WorkerState = { payloadSizes?: CommandPayloadSizes };
+export type WorkerState = {
+  /**
+   * The version of the .slp spec that was used when the file was created. Some
+   * fields are only present after certain versions.
+   */
+  replayFormatVersion?: string,
+  payloadSizes?: CommandPayloadSizes
+};
 
-const workerState: WorkerState = { payloadSizes: undefined };
+const workerState: WorkerState = {
+  replayFormatVersion: undefined,
+  payloadSizes: undefined
+};
 
 onmessage = (event: MessageEvent<WorkerInput>) => {
   console.log("worker got event", event);

--- a/assets/src/common/types.ts
+++ b/assets/src/common/types.ts
@@ -44,11 +44,12 @@ export type SpectateData = {
 }
 
 export type NonReactiveState = {
-  payloadSizes: CommandPayloadSizes | undefined;
+  payloadSizes?: CommandPayloadSizes;
   /**
    * Player control starts at 84. Timer starts at 123.
    */
   gameFrames: Frame[];
+  latestFinalizedFrame?: number;
 }
 
 /**
@@ -65,6 +66,7 @@ export type FrameStartEvent = { frameNumber: number, randomSeed: number };
 export type ItemUpdateEvent = ItemUpdate;
 export type GameEndEvent = GameEnding;
 export type GameStartEvent = GameSettings;
+export type FrameBookendEvent = FrameBookend
 
 export type GameEvent = {
   type: "pre_frame_update",
@@ -87,7 +89,10 @@ export type GameEvent = {
 } | {
   type: "game_start",
   data: GameStartEvent
-}
+} | {
+  type: "frame_bookend",
+  data: FrameBookendEvent
+};
 
 export interface GameSettings {
   /**
@@ -290,6 +295,11 @@ export interface ItemUpdate {
   /** Mewtwo/Samus */
   readonly chargeShotChargeLevel: number;
   readonly owner: number;
+}
+
+export interface FrameBookend {
+  readonly frameNumber: number;
+  readonly latestFinalizedFrame: number;
 }
 
 /**

--- a/assets/src/state/spectateStore.tsx
+++ b/assets/src/state/spectateStore.tsx
@@ -206,23 +206,7 @@ function initPlayerIfNeeded(
   return { ...frame, players };
 }
 
-function isRollbackFromFrameUpdate(frames: Frame[], frameNumber: number): boolean {
-  const maybeFrame = frames[frameNumber];
-  return Boolean(maybeFrame && maybeFrame.players);
-}
-
 function handlePreFrameUpdateEvent(playerInputs: PreFrameUpdateEvent): void {
-  if (false /* TODO: Fix isRollbackFromFrameUpdate(nonReactiveState.gameFrames, playerInputs.frameNumber) */) {
-    console.log('setting frame from preframe rollback')
-    // Cut off stale frames, and roll back to the new playback point.
-    // Relies on updates being batched, as otherwise the frame would
-    // not yet be finished at this point.
-    const frames = nonReactiveState.gameFrames.slice(0, playerInputs.frameNumber + 1);
-    // setReplayState("playbackData", { ...replayState.playbackData!, frames });
-    nonReactiveState.gameFrames = frames;
-    setReplayState("frame", playerInputs.frameNumber);
-  }
-
   // Some older versions don't have the Frame Start Event so we have to
   // potentially initialize the frame in both places.
   let frame = initFrameIfNeeded(nonReactiveState.gameFrames /* replayState.playbackData!.frames */, playerInputs.frameNumber);
@@ -252,16 +236,6 @@ function handlePreFrameUpdateEvent(playerInputs: PreFrameUpdateEvent): void {
 }
 
 function handlePostFrameUpdateEvent(playerState: PostFrameUpdateEvent): void {
-  if (false /* TODO: Fix isRollbackFromFrameUpdate(nonReactiveState.gameFrames, playerState.frameNumber) */) {
-    // Cut off stale frames, and roll back to the new playback point.
-    // Relies on updates being batched, as otherwise the frame would
-    // not yet be finished at this point.
-    // const frames = replayState.playbackData!.frames.slice(0, playerState.frameNumber + 1);
-    // setReplayState("playbackData", { ...replayState.playbackData!, frames });
-    nonReactiveState.gameFrames = nonReactiveState.gameFrames.slice(0, playerState.frameNumber + 1);
-    setReplayState("frame", playerState.frameNumber);
-  }
-
   // const frame = replayState.playbackData!.frames[playerState.frameNumber];
   const frame = nonReactiveState.gameFrames[playerState.frameNumber];
   if (playerState.isNana) {

--- a/assets/src/state/spectateStore.tsx
+++ b/assets/src/state/spectateStore.tsx
@@ -128,7 +128,7 @@ const [running, start, stop] = createRAF(
     () => {
       // TODO: Fix joining replay mid-game
       const tryFrame = replayState.frame + replayState.framesPerTick;
-      if (tryFrame <= (nonReactiveState.latestFinalizedFrame ?? 0)) {
+      if (tryFrame < (nonReactiveState.latestFinalizedFrame ?? 0)) {
         setReplayState("frame", tryFrame);
       }
     },

--- a/assets/src/state/spectateStore.tsx
+++ b/assets/src/state/spectateStore.tsx
@@ -313,7 +313,12 @@ function handleItemUpdateEvent(itemUpdate: ItemUpdateEvent): void {
 }
 
 function handleFrameBookendEvent(frameBookend: FrameBookendEvent): void {
+  const prevLatestFrame = nonReactiveState.latestFinalizedFrame;
   nonReactiveState.latestFinalizedFrame = frameBookend.latestFinalizedFrame;
+
+  if (prevLatestFrame === undefined) {
+    setReplayState("frame", nonReactiveState.latestFinalizedFrame);
+  }
 }
 
 createRoot(() => {

--- a/assets/src/workerUtil.ts
+++ b/assets/src/workerUtil.ts
@@ -9,6 +9,8 @@ export function createWorker(bridgeId: string) {
   worker.onmessage = (event: MessageEvent) => {
     const gameEvents: GameEvent[] = event.data.value;
 
+    // Works without batch now, but might still want it for smoothness.
+    // To consider alongside changed buffer logic.
     batch(() => {
       gameEvents.forEach((gameEvent) => {
         setReplayStateFromGameEvent(gameEvent)


### PR DESCRIPTION
This PR parses and processes the frame bookend event to be able to track the latest finalized frame, instead of relying on broken rollback logic.

This does not yet introduce some kind of frame buffer to help ensure 60fps live replays.