### PR TITLE
Rewindable on join

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@gcpreston/slippi-viewer": "^0.1.1"
+        "@gcpreston/slippi-viewer": "^0.1.2"
       }
     },
     "node_modules/@gcpreston/slippi-viewer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@gcpreston/slippi-viewer/-/slippi-viewer-0.1.1.tgz",
-      "integrity": "sha512-cMc+y63RpTeiFkHkg6IObh6DaNZCFBr75r3s0sBAtBsZ+ERFodMmpZiyCMnObw9iTRqwhhWsK1eAFxiss7j0pQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@gcpreston/slippi-viewer/-/slippi-viewer-0.1.2.tgz",
+      "integrity": "sha512-rice/U13bkb6zsI64xqi6W3kjOwKSvlpiy4ENEqeVGWvdxK4DjiC9fS+vVaRPFGsBM+ZvERvZa+9WpNb4/olTw==",
       "license": "MIT",
       "dependencies": {
         "@shelacek/ubjson": "^1.1.1",
@@ -28,21 +28,21 @@
       "license": "MIT"
     },
     "node_modules/@solid-primitives/raf": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@solid-primitives/raf/-/raf-2.3.0.tgz",
-      "integrity": "sha512-igL6r/wRbADoee717uT2Z4VYphMuWRIWBR7iREWavgfSVFrATG9Fj7SJYnMa/Wdx1aEfdtOtO5cf8T8jcTNH1w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@solid-primitives/raf/-/raf-2.3.1.tgz",
+      "integrity": "sha512-0njLtSkdoVAAIv5hD7/rYTPt3NEIyO3lfCIrC17RJ+ycLT6+Y7ckopT9Eow2onwFGrkK05jZpMsuph7hVl2/ng==",
       "license": "MIT",
       "dependencies": {
-        "@solid-primitives/utils": "^6.3.0"
+        "@solid-primitives/utils": "^6.3.1"
       },
       "peerDependencies": {
         "solid-js": "^1.6.12"
       }
     },
     "node_modules/@solid-primitives/utils": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@solid-primitives/utils/-/utils-6.3.0.tgz",
-      "integrity": "sha512-e7hTlJ1Ywh2+g/Qug+n4L1mpfxsikoIS4/sHE2EK9WatQt8UJqop/vE6bsLnXlU1xuhb/jo94Ah5Y27rd4wP7A==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@solid-primitives/utils/-/utils-6.3.1.tgz",
+      "integrity": "sha512-4/Z59nnwu4MPR//zWZmZm2yftx24jMqQ8CSd/JobL26TPfbn4Ph8GKNVJfGJWShg1QB98qObJSskqizbTvcLLA==",
       "license": "MIT",
       "peerDependencies": {
         "solid-js": "^1.6.12"
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.5.tgz",
-      "integrity": "sha512-ogI3DaFcyn6UhYhrgcyRAMbu/buBJitYQASZz5WzfQVPP10RD2AbCoRZ517psnezrasyCbWzIxZ6kVqet768xw==",
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.6.tgz",
+      "integrity": "sha512-PoasAJvLk60hRtOTe9ulvALOdLjjqxuxcGZRolBQqxOnXrBXHGzqMT4ijNhGsDAYdOgEa8ZYaAE94PSldrFSkA==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.0",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@gcpreston/slippi-viewer": "^0.1.2"
+        "@gcpreston/slippi-viewer": "^0.1.3"
       }
     },
     "node_modules/@gcpreston/slippi-viewer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@gcpreston/slippi-viewer/-/slippi-viewer-0.1.2.tgz",
-      "integrity": "sha512-rice/U13bkb6zsI64xqi6W3kjOwKSvlpiy4ENEqeVGWvdxK4DjiC9fS+vVaRPFGsBM+ZvERvZa+9WpNb4/olTw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@gcpreston/slippi-viewer/-/slippi-viewer-0.1.3.tgz",
+      "integrity": "sha512-ybYe+owfcd3SwuzDC+LQkBQnoOxexaVvM4mA8FMx3uM7PFajLkrDIuEe8pLDcbYvgl319ZsSB+uIa7pYQEO+Rg==",
       "license": "MIT",
       "dependencies": {
         "@shelacek/ubjson": "^1.1.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@gcpreston/slippi-viewer": "^0.1.2"
+    "@gcpreston/slippi-viewer": "^0.1.3"
   }
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@gcpreston/slippi-viewer": "^0.1.1"
+    "@gcpreston/slippi-viewer": "^0.1.2"
   }
 }

--- a/lib/spectator_mode_web/viewer_socket.ex
+++ b/lib/spectator_mode_web/viewer_socket.ex
@@ -13,10 +13,10 @@ defmodule SpectatorModeWeb.ViewerSocket do
   @impl true
   def connect(%{params: %{"bridge_id" => bridge_id}} = state) do
     bridge_relay_name = {:via, Registry, {BridgeRegistry, bridge_id}}
-    maybe_current_metadata = BridgeRelay.subscribe(bridge_relay_name)
+    maybe_current_game = BridgeRelay.subscribe(bridge_relay_name)
 
-    if maybe_current_metadata do
-      send(self(), {:after_join, maybe_current_metadata})
+    if maybe_current_game do
+      send(self(), {:after_join, maybe_current_game})
     end
 
     {:ok, state}
@@ -34,9 +34,9 @@ defmodule SpectatorModeWeb.ViewerSocket do
   end
 
   @impl true
-  def handle_info({:after_join, current_metadata}, state) do
-    # Forward the current game metadata to the specator who just connected
-    {:push, {:binary, current_metadata}, state}
+  def handle_info({:after_join, current_game}, state) do
+    # Forward the current game binary to the specator who just connected
+    {:push, {:binary, current_game}, state}
   end
 
   def handle_info({:game_data, payload}, state) do


### PR DESCRIPTION
This PR makes it so the relay stores every packet as it comes it, and forwards them all to any new viewers. It likewise expects the bridge to send it all current game packets upon connection. This enables rewind beyond the point of join.