### PR TITLE
Fast stream join

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@gcpreston/slippi-viewer": "^0.1.7"
+        "@gcpreston/slippi-viewer": "^0.1.8"
       }
     },
     "node_modules/@gcpreston/slippi-viewer": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@gcpreston/slippi-viewer/-/slippi-viewer-0.1.7.tgz",
-      "integrity": "sha512-wIj/s5ADCQ1cqtcG7Mvq74afx2qqImSbUSjZxBnixA3dv9KnmkZ6r94LYRURw1chldpv2uG/rLMK42qUs2Z0Fg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@gcpreston/slippi-viewer/-/slippi-viewer-0.1.8.tgz",
+      "integrity": "sha512-URjzWv2X9ENP8aK4UZ/BtSvI5ruTFBJh994jmGo4BwF1aH44xpbGS0P3L/JTLCbomWu++9xNPO3Blnm9zBcPNQ==",
       "license": "MIT",
       "dependencies": {
         "@shelacek/ubjson": "^1.1.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@gcpreston/slippi-viewer": "^0.1.7"
+    "@gcpreston/slippi-viewer": "^0.1.8"
   }
 }

--- a/lib/spectator_mode/bridge_relay.ex
+++ b/lib/spectator_mode/bridge_relay.ex
@@ -109,8 +109,17 @@ defmodule SpectatorMode.BridgeRelay do
 
   @impl true
   def handle_call(:subscribe, {from_pid, _tag}, %{subscribers: subscribers} = state) do
-    {:reply, state.current_game_packets |> Enum.reverse() |> Enum.join(),
-     %{state | subscribers: MapSet.put(subscribers, from_pid)}}
+    binary_to_send =
+      [
+        state.event_payloads.binary,
+        state.current_game_start.binary,
+        state.current_game_state.fod_platforms.left,
+        state.current_game_state.fod_platforms.right
+      ]
+      |> Enum.filter(&(!is_nil(&1)))
+      |> Enum.join()
+
+    {:reply, binary_to_send, %{state | subscribers: MapSet.put(subscribers, from_pid)}}
   end
 
   def handle_call({:reconnect, source_pid}, _from, state) do

--- a/lib/spectator_mode/bridge_relay.ex
+++ b/lib/spectator_mode/bridge_relay.ex
@@ -9,14 +9,6 @@ defmodule SpectatorMode.BridgeRelay do
   alias SpectatorMode.BridgeRegistry
   alias SpectatorMode.ReconnectTokenStore
 
-  # TODO: Snappy join
-  # 1. Parse stage events (FoD platforms specifcially)
-  # 2. Track current stage state in BridgeRelay
-  # 3. Send current stage state on subscribe; don't send whole game
-  #    - whole game will still be received upon bridge connection,
-  #      but it will not be sent to viewers
-  #    - viewers won't be able to rewind before viewing point for this PR
-
   @enforce_keys [:bridge_id, :reconnect_token]
   defstruct bridge_id: nil,
             subscribers: MapSet.new(),

--- a/lib/spectator_mode/bridge_relay.ex
+++ b/lib/spectator_mode/bridge_relay.ex
@@ -1,14 +1,21 @@
 defmodule SpectatorMode.BridgeRelay do
   use GenServer, restart: :temporary
-  # Use temporary restart while client closes on WebSocket error. Once the
-  # client is made to be more fault tolerant and can stay open, this can
-  # be transient.
+  # Temporary restart => new BridgeRelay upon bridge disconnect and reconnect.
+  # This is for simplicity, this can probably be optimized in the future.
 
   require Logger
   alias SpectatorMode.Streams
   alias SpectatorMode.Slp
   alias SpectatorMode.BridgeRegistry
   alias SpectatorMode.ReconnectTokenStore
+
+  # TODO: Snappy join
+  # 1. Parse stage events (FoD platforms specifcially)
+  # 2. Track current stage state in BridgeRelay
+  # 3. Send current stage state on subscribe; don't send whole game
+  #    - whole game will still be received upon bridge connection,
+  #      but it will not be sent to viewers
+  #    - viewers won't be able to rewind before viewing point for this PR
 
   @enforce_keys [:bridge_id, :reconnect_token]
   defstruct bridge_id: nil,

--- a/lib/spectator_mode/slp/events.ex
+++ b/lib/spectator_mode/slp/events.ex
@@ -41,4 +41,15 @@ defmodule SpectatorMode.Slp.Events do
     @enforce_keys [:binary]
     defstruct [:binary]
   end
+
+  defmodule FodPlatforms do
+    @type t :: %__MODULE__{
+      binary: binary(),
+      frame_number: integer(),
+      platform: :left | :right,
+      height: float()
+    }
+    @enforce_keys [:binary, :frame_number, :platform, :height]
+    defstruct [:binary, :frame_number, :platform, :height]
+  end
 end

--- a/lib/spectator_mode_web/viewer_socket.ex
+++ b/lib/spectator_mode_web/viewer_socket.ex
@@ -14,10 +14,11 @@ defmodule SpectatorModeWeb.ViewerSocket do
   @impl true
   def connect(%{params: %{"bridge_id" => bridge_id}} = state) do
     bridge_relay_name = {:via, Registry, {BridgeRegistry, bridge_id}}
-    maybe_current_game = BridgeRelay.subscribe(bridge_relay_name)
+    join_payload = BridgeRelay.subscribe(bridge_relay_name)
 
-    if maybe_current_game do
-      send(self(), {:after_join, maybe_current_game})
+    # Send initial data to viewer after connect
+    if join_payload do
+      send(self(), {:after_join, join_payload})
     end
 
     # Track presence
@@ -39,9 +40,8 @@ defmodule SpectatorModeWeb.ViewerSocket do
   end
 
   @impl true
-  def handle_info({:after_join, current_game}, state) do
-    # Forward the current game binary to the specator who just connected
-    {:push, {:binary, current_game}, state}
+  def handle_info({:after_join, join_payload}, state) do
+    {:push, {:binary, join_payload}, state}
   end
 
   def handle_info({:game_data, payload}, state) do


### PR DESCRIPTION
This PR improves viewer connect performance by not sending the whole game upon connection.

Sending the whole game was originally changed to easily support current FoD platform height rendering, since it seemed it was still fast on local. In reality, the event parsing is fast on the frontend, but the data transfer can be slow over the network in production, causing significant lag loading the stream, and often rendering issues once it is loaded.

This PR addresses this issue by transferring the minimum amount of stateful information to the viewer upon connection. Specifically, this means event payloads, game start, and the latest left + right FoD platform events. 

The corresponding slippi-viewer changes can be found here: https://github.com/gcpreston/slippi-viewer/commit/5a83069fc21f595770c2afe635f3cf1788e9affd