### PR TITLE
Allow fetching full replay on viewer connect

### DIFF
--- a/lib/spectator_mode/dynamic_processes/packet_handler.ex
+++ b/lib/spectator_mode/dynamic_processes/packet_handler.ex
@@ -70,7 +70,7 @@ defmodule SpectatorMode.PacketHandler do
 
   @impl true
   def handle_call(:get_replay, _from, state) do
-    {:reply, state.replay_so_far, state}
+    {:reply, state.replay_so_far || <<>>, state}
   end
 
   ## Helpers

--- a/lib/spectator_mode/streams.ex
+++ b/lib/spectator_mode/streams.ex
@@ -57,12 +57,21 @@ defmodule SpectatorMode.Streams do
 
   @doc """
   Register the calling process to receive data from a specified livestream.
+
+  Returns the Slippi events from an ongoing game needed to interpret the game
+  state. By default, this is a minimal collection, suitable for in-browser
+  viewing, but if the full replay so far is needed, the `return_full_replay`
+  parameter can be passed as `true`.
   """
-  @spec register_viewer(stream_id()) :: viewer_connect_result()
-  def register_viewer(stream_id) do
+  @spec register_viewer(stream_id(), boolean()) :: viewer_connect_result()
+  def register_viewer(stream_id, return_full_replay \\ false) do
     Phoenix.PubSub.subscribe(SpectatorMode.PubSub, stream_subtopic(stream_id))
-    # GameTracker.join_payload(stream_id)
-    PacketHandler.get_replay({:via, Registry, {PacketHandlerRegistry, stream_id}})
+
+    if return_full_replay do
+      PacketHandler.get_replay({:via, Registry, {PacketHandlerRegistry, stream_id}})
+    else
+      GameTracker.join_payload(stream_id)
+    end
   end
 
   @doc """

--- a/lib/spectator_mode_web/viewer_socket.ex
+++ b/lib/spectator_mode_web/viewer_socket.ex
@@ -14,9 +14,10 @@ defmodule SpectatorModeWeb.ViewerSocket do
   # Desired behavior: On viewer reconnect case, send missing frames
 
   @impl true
-  def connect(%{params: %{"stream_id" => stream_id}} = state) do
+  def connect(%{params: %{"stream_id" => stream_id} = params} = state) do
     stream_id = String.to_integer(stream_id)
-    join_payload = Streams.register_viewer(stream_id)
+    get_full_replay = !!Map.get(params, "full_replay", false)
+    join_payload = Streams.register_viewer(stream_id, get_full_replay)
 
     # Send initial data to viewer after connect
     if join_payload do


### PR DESCRIPTION
This PR adds the optional query param `full_replay` to the viewer socket endpoint, which takes a binary value. If set to `true`, after connection the server will send the full binary instead of only the necessary events. 

PLEASE NOTE that right now this is a bit of a hack. It may seem odd that the replay is stored on PacketHandler rather than GameTracker, as if it was still the old Livestream process. There are also questions of whether it's possible to miss a cursor with this approach. Both of these are valid concerns, and will be addressed in a future PR. The purpose of this quick-and-dirty approach now is to provide an API to go off of, and to allow building the `swb` logic against the deployed web server instead of just the local one.